### PR TITLE
Stop mirroring output files to Downloads

### DIFF
--- a/app_context.py
+++ b/app_context.py
@@ -39,6 +39,7 @@ APP_VERSION = "0.1.0"
 
 
 COMPLETED_DIRNAME = f"{APP_SLUG}_Completed"
+TEXTPAGES_DIRNAME = f"{APP_SLUG}_TextPages"
 
 
 def _share_root(app_id: str) -> str:
@@ -107,6 +108,8 @@ class AppContext:
     user_regex_dir: str = field(init=False)
     user_post_dir: str = field(init=False)
     completed_host: str = field(init=False)
+    host_view_text: str = field(init=False)
+    shm_completed_dir: str = field(init=False)
     shm_root: str = field(init=False)
     shm_text_dir: str = field(init=False)
     shm_toc_dir: str = field(init=False)
@@ -127,10 +130,14 @@ class AppContext:
         self.shm_root = _runtime_root(self.app_slug)
         self.shm_text_dir = os.path.join(self.shm_root, "TextPages")
         self.shm_toc_dir = os.path.join(self.shm_root, "TOC")
-        self.completed_host = os.path.join(self.shm_root, COMPLETED_DIRNAME)
+        self.shm_completed_dir = os.path.join(self.shm_root, COMPLETED_DIRNAME)
         self.toc_file_path = os.path.join(self.shm_toc_dir, "toc.txt")
         self.combined_pdf_path = os.path.join(self.shm_root, "combined_tmp.pdf")
-        self.completed_record_pdf = os.path.join(self.completed_host, "bookmarked.pdf")
+        self.completed_record_pdf = os.path.join(self.shm_completed_dir, "bookmarked.pdf")
+
+        persist_root = _xdg(self.app_slug, "data", "output")
+        self.completed_host = os.path.join(persist_root, COMPLETED_DIRNAME)
+        self.host_view_text = os.path.join(persist_root, TEXTPAGES_DIRNAME)
 
     # ── Seeding & directory helpers ────────────────────────────────────────
     def seed_user_data(self) -> tuple[bool, bool, bool]:
@@ -153,7 +160,9 @@ class AppContext:
                 self.input_folder,
                 self.user_regex_dir,
                 self.user_post_dir,
+                self.shm_completed_dir,
                 self.completed_host,
+                self.host_view_text,
             ):
                 os.makedirs(folder, exist_ok=True)
             dlog("Created runtime/config/data dirs")

--- a/app_context.py
+++ b/app_context.py
@@ -39,7 +39,6 @@ APP_VERSION = "0.1.0"
 
 
 COMPLETED_DIRNAME = f"{APP_SLUG}_Completed"
-TEXTPAGES_DIRNAME = f"{APP_SLUG}_TextPages"
 
 
 def _share_root(app_id: str) -> str:
@@ -107,9 +106,7 @@ class AppContext:
     input_folder: str = field(init=False)
     user_regex_dir: str = field(init=False)
     user_post_dir: str = field(init=False)
-    downloads_base: str = field(init=False)
     completed_host: str = field(init=False)
-    host_view_text: str = field(init=False)
     shm_root: str = field(init=False)
     shm_text_dir: str = field(init=False)
     shm_toc_dir: str = field(init=False)
@@ -127,14 +124,10 @@ class AppContext:
         self.user_regex_dir = _xdg(self.app_slug, "config", "regexes")
         self.user_post_dir = _xdg(self.app_slug, "config", "post_processing")
 
-        downloads_dir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DOWNLOAD)
-        self.downloads_base = downloads_dir or os.path.expanduser("~/Downloads")
-        self.completed_host = os.path.join(self.downloads_base, COMPLETED_DIRNAME)
-        self.host_view_text = os.path.join(self.downloads_base, TEXTPAGES_DIRNAME)
-
         self.shm_root = _runtime_root(self.app_slug)
         self.shm_text_dir = os.path.join(self.shm_root, "TextPages")
         self.shm_toc_dir = os.path.join(self.shm_root, "TOC")
+        self.completed_host = os.path.join(self.shm_root, COMPLETED_DIRNAME)
         self.toc_file_path = os.path.join(self.shm_toc_dir, "toc.txt")
         self.combined_pdf_path = os.path.join(self.shm_root, "combined_tmp.pdf")
         self.completed_record_pdf = os.path.join(self.completed_host, "bookmarked.pdf")
@@ -161,7 +154,6 @@ class AppContext:
                 self.user_regex_dir,
                 self.user_post_dir,
                 self.completed_host,
-                self.host_view_text,
             ):
                 os.makedirs(folder, exist_ok=True)
             dlog("Created runtime/config/data dirs")

--- a/copy_by_number.py
+++ b/copy_by_number.py
@@ -1,6 +1,7 @@
 # copy_by_number.py
 from __future__ import annotations
 import os
+import tempfile
 from pathlib import Path
 
 import gi
@@ -20,7 +21,7 @@ class CopyByNumber:
           1) self.text_record_folder (if your app sets it)
           2) global 'shm_text_dir' (if defined elsewhere)
           3) env PDFMARKER_TEXT_PAGES_DIR
-          4) ~/Downloads/DogEar_TextPages  (fallback)
+          4) runtime temp dir / DogEar_TextPages (fallback)
         """
         if hasattr(self, "text_record_folder"):
             return getattr(self, "text_record_folder")
@@ -30,7 +31,10 @@ class CopyByNumber:
         env_dir = os.environ.get("PDFMARKER_TEXT_PAGES_DIR")
         if env_dir:
             return env_dir
-        return str(Path.home() / "Downloads" / "DogEar_TextPages")
+        runtime_root = os.environ.get("XDG_RUNTIME_DIR")
+        if runtime_root:
+            return os.path.join(runtime_root, "DogEar", "DogEar_TextPages")
+        return str(Path(tempfile.gettempdir()) / "DogEar_TextPages")
 
     @staticmethod
     def _format_page_filename(self, n: int) -> str:

--- a/window.py
+++ b/window.py
@@ -128,7 +128,10 @@ class DogEarWindow(Adw.ApplicationWindow):
 
         self.row_toc.connect("activated", self._on_row_create_toc)
         self.row_bm.connect("activated", self._on_row_create_bookmarks)
-        self.row_dir.connect("activated", lambda *_: self._open_path(None, self.ctx.completed_host))
+        self.row_dir.connect(
+            "activated",
+            lambda *_: self._open_path(None, self.ctx.completed_host, self.ctx.shm_completed_dir),
+        )
 
         editor_section = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         editor_section.set_vexpand(True)
@@ -209,10 +212,20 @@ class DogEarWindow(Adw.ApplicationWindow):
         ensure("open_input", lambda *_: self._open_path(None, self.ctx.input_folder))
         ensure("open_regex", lambda *_: self._open_path(None, self.ctx.user_regex_dir))
         ensure("open_posts", lambda *_: self._open_path(None, self.ctx.user_post_dir))
-        ensure("open_text", lambda *_: self._open_path(None, self.ctx.shm_text_dir))
+        ensure(
+            "open_text",
+            lambda *_: self._open_path(
+                None, self.ctx.host_view_text, self.ctx.shm_text_dir
+            ),
+        )
         ensure("copy_text_number", self._on_copy_text_number)
         ensure("copy_regex_pattern", self._on_copy_regex_pattern)
-        ensure("open_completed", lambda *_: self._open_path(None, self.ctx.completed_host))
+        ensure(
+            "open_completed",
+            lambda *_: self._open_path(
+                None, self.ctx.completed_host, self.ctx.shm_completed_dir
+            ),
+        )
         ensure("about", self._on_about)
 
     def _build_app_menu(self) -> Gtk.PopoverMenu:
@@ -438,8 +451,10 @@ class DogEarWindow(Adw.ApplicationWindow):
             daemon=True,
         ).start()
 
-    def _open_path(self, _button, path: str) -> None:
+    def _open_path(self, _button, path: str, refresh_from: str | None = None) -> None:
         try:
+            if refresh_from:
+                self.runner.mirror_tree(refresh_from, path)
             os.makedirs(path, exist_ok=True)
             uri = dir_uri(path)
 

--- a/window.py
+++ b/window.py
@@ -128,9 +128,7 @@ class DogEarWindow(Adw.ApplicationWindow):
 
         self.row_toc.connect("activated", self._on_row_create_toc)
         self.row_bm.connect("activated", self._on_row_create_bookmarks)
-        self.row_dir.connect(
-            "activated", lambda *_: self._open_path(None, self.ctx.completed_host, False)
-        )
+        self.row_dir.connect("activated", lambda *_: self._open_path(None, self.ctx.completed_host))
 
         editor_section = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         editor_section.set_vexpand(True)
@@ -208,13 +206,13 @@ class DogEarWindow(Adw.ApplicationWindow):
                 action.connect("activate", handler)
                 app.add_action(action)
 
-        ensure("open_input", lambda *_: self._open_path(None, self.ctx.input_folder, False))
-        ensure("open_regex", lambda *_: self._open_path(None, self.ctx.user_regex_dir, False))
-        ensure("open_posts", lambda *_: self._open_path(None, self.ctx.user_post_dir, False))
-        ensure("open_text", lambda *_: self._open_path(None, self.ctx.shm_text_dir, True))
+        ensure("open_input", lambda *_: self._open_path(None, self.ctx.input_folder))
+        ensure("open_regex", lambda *_: self._open_path(None, self.ctx.user_regex_dir))
+        ensure("open_posts", lambda *_: self._open_path(None, self.ctx.user_post_dir))
+        ensure("open_text", lambda *_: self._open_path(None, self.ctx.shm_text_dir))
         ensure("copy_text_number", self._on_copy_text_number)
         ensure("copy_regex_pattern", self._on_copy_regex_pattern)
-        ensure("open_completed", lambda *_: self._open_path(None, self.ctx.completed_host, False))
+        ensure("open_completed", lambda *_: self._open_path(None, self.ctx.completed_host))
         ensure("about", self._on_about)
 
     def _build_app_menu(self) -> Gtk.PopoverMenu:
@@ -440,15 +438,10 @@ class DogEarWindow(Adw.ApplicationWindow):
             daemon=True,
         ).start()
 
-    def _open_path(self, _button, path: str, mirror: bool) -> None:
+    def _open_path(self, _button, path: str) -> None:
         try:
             os.makedirs(path, exist_ok=True)
-            open_path = path
-            if mirror and os.path.abspath(path) == os.path.abspath(self.ctx.shm_text_dir):
-                self.runner.mirror_tree(path, self.ctx.host_view_text)
-                open_path = self.ctx.host_view_text
-
-            uri = dir_uri(open_path)
+            uri = dir_uri(path)
 
             if hasattr(Gtk, "UriLauncher"):
                 launcher = Gtk.UriLauncher.new(uri)
@@ -472,7 +465,7 @@ class DogEarWindow(Adw.ApplicationWindow):
                         try:
                             subprocess.run(["xdg-open", uri], check=True)
                         except Exception as exc_inner:
-                            self._set_status(f"Open failed: {open_path} — {exc_inner}")
+                            self._set_status(f"Open failed: {path} — {exc_inner}")
 
                 launcher.launch(self, None, done)
                 return
@@ -487,7 +480,7 @@ class DogEarWindow(Adw.ApplicationWindow):
                 subprocess.run(["xdg-open", uri], check=True)
                 return
             except Exception as exc:
-                self._set_status(f"Open failed: {open_path} — {exc}")
+                self._set_status(f"Open failed: {path} — {exc}")
 
         except Exception as exc:
             self._set_status(f"Open failed: {path} — {exc}")

--- a/workflows.py
+++ b/workflows.py
@@ -163,7 +163,6 @@ class WorkflowRunner:
                 )
 
             self._load_toc()
-            self.mirror_tree(self._ctx.shm_text_dir, self._ctx.host_view_text)
 
             output = (process.stdout or "").strip()
             base = os.path.basename(script_path)
@@ -172,27 +171,4 @@ class WorkflowRunner:
             )
         except Exception as exc:
             self._set_status(f"Script failed: {exc}")
-
-    # ── File utilities ─────────────────────────────────────────────────────
-    def mirror_tree(self, src: str, dst: str) -> None:
-        try:
-            os.makedirs(dst, exist_ok=True)
-            for name in os.listdir(dst):
-                target = os.path.join(dst, name)
-                try:
-                    shutil.rmtree(target) if os.path.isdir(target) else os.remove(target)
-                except Exception:
-                    pass
-            for name in os.listdir(src):
-                source = os.path.join(src, name)
-                target = os.path.join(dst, name)
-                try:
-                    if os.path.isdir(source):
-                        shutil.copytree(source, target)
-                    else:
-                        shutil.copy2(source, target)
-                except Exception:
-                    pass
-        except Exception as exc:
-            self._set_status(f"Mirror failed: {exc}")
 


### PR DESCRIPTION
## Summary
- keep generated text files and bookmarked PDFs in the runtime storage area instead of mirroring them to Downloads
- update menu actions and path handling so the app opens the in-memory locations directly
- refresh text-directory fallback logic to prefer runtime temp storage over the user Downloads folder

## Testing
- python -m compileall app_context.py copy_by_number.py window.py workflows.py

------
https://chatgpt.com/codex/tasks/task_e_68dfc48c8800832d92ab81c0eb43e6f5